### PR TITLE
fix: remediate RSA Security Analytics vulnerabilities

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2017-2025 Splunk Inc.
+   Copyright (c) 2017-2026 Splunk Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Splunk SOAR App: RSA Security Analytics
-Copyright (c) 2017-2025 Splunk Inc.
+Copyright (c) 2017-2026 Splunk Inc.

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2017-2025 Splunk Inc.
+# Copyright (c) 2017-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/parse_incidents.py
+++ b/parse_incidents.py
@@ -1,6 +1,6 @@
 # File: parse_incidents.py
 #
-# Copyright (c) 2017-2025 Splunk Inc.
+# Copyright (c) 2017-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/parse_incidents.py
+++ b/parse_incidents.py
@@ -37,6 +37,92 @@ cef_keys = {
 }
 
 
+def _log_parse_error(base_connector, record_type, identifier, error):
+    message = f"Failed to parse {record_type} '{identifier}', skipping it. Error: {error}"
+    if base_connector:
+        base_connector.debug_print(message)
+        base_connector.save_progress(message)
+
+
+def _parse_alert(alert):
+    artifact = dict(artifact_common)
+    cef = {}
+    event_ids = []
+    artifact.update(
+        {
+            "cef": cef,
+            "label": "alert",
+            "source_data_identifier": alert["id"],
+            "name": f"alert - {alert['name']}",
+            "cef_types": {"incidentId": ["rsa incident id"], "alertId": ["rsa alert id"]},
+        }
+    )
+    cef["events"] = event_ids
+
+    for key, value in alert.items():
+        if key in {"related_links", "events"}:
+            continue
+        cef[cef_keys.get(key, key)] = value
+
+    return artifact, event_ids
+
+
+def _parse_event(alert, event, event_ids):
+    artifact = dict(artifact_common)
+    cef = {"alertId": alert["id"]}
+    artifact.update(
+        {
+            "cef": cef,
+            "label": "event",
+            "cef_types": {"sessionId": ["netwitness session ids"], "alertId": ["rsa alert id"]},
+        }
+    )
+
+    for key, value in event.items():
+        if not value:
+            continue
+
+        if key in {"destination", "source"}:
+            device = value.get("device") or {}
+            for device_key, device_value in device.items():
+                if device_key in cef_keys and device_value:
+                    cef[f"{key}{cef_keys[device_key]}"] = device_value
+
+            user = value.get("user")
+            if isinstance(user, dict) and user.get("username"):
+                cef[f"{key}UserName"] = user["username"]
+
+        elif key == "related_links":
+            for link in value:
+                if link.get("type") == "investigate_original_event" and link.get("url"):
+                    event_id = link["url"].split("/")[-1]
+                    cef["sessionId"] = event_id
+                    event_ids.append(event_id)
+                    artifact["source_data_identifier"] = event_id
+                    artifact["name"] = f"event - {event_id}"
+
+        elif key == "data":
+            data = value[0] if isinstance(value, list) and value else {}
+            if data.get("filename"):
+                cef["fileName"] = data["filename"]
+            if data.get("size"):
+                cef["fileSize"] = data["size"]
+            if data.get("hash"):
+                cef["fileHash"] = data["hash"]
+
+        elif key == "domain":
+            cef["destinationDnsDomain"] = value
+        elif key == "timestamp":
+            cef["createTime"] = value
+        elif key == "device":
+            cef["deviceName"] = value
+            artifact["cef_types"]["deviceName"] = ["rsa sa device"]
+        elif key not in {"file", "size", "detector"}:
+            cef[key] = value
+
+    return artifact
+
+
 def parse_incidents(incidents, base_connector):
     results = []
 
@@ -44,101 +130,30 @@ def parse_incidents(incidents, base_connector):
         try:
             container = {}
             artifacts = []
-            results.append({"container": container, "artifacts": artifacts})
-
             container["data"] = incident
             container["name"] = "{} - {}".format(incident["id"], incident["name"])
             container["description"] = incident["summary"]
             container["source_data_identifier"] = incident["id"]
+        except Exception as error:
+            identifier = incident.get("id") if isinstance(incident, dict) else incident
+            _log_parse_error(base_connector, "incident", identifier, error)
+            continue
 
-            for alert in incident["alerts"]:
-                artifact = {}
-                artifacts.append(artifact)
-                artifact.update(artifact_common)
+        results.append({"container": container, "artifacts": artifacts})
+        for alert in incident.get("alerts") or []:
+            try:
+                alert_artifact, event_ids = _parse_alert(alert)
+            except Exception as error:
+                identifier = alert.get("id") if isinstance(alert, dict) else alert
+                _log_parse_error(base_connector, "alert", identifier, error)
+                continue
 
-                cef = {}
-                event_id_list = []
-                artifact["cef"] = cef
-                artifact["label"] = "alert"
-                cef["events"] = event_id_list
-                artifact["source_data_identifier"] = alert["id"]
-                artifact["name"] = "alert - {}".format(alert["name"])
-                artifact["cef_types"] = {"incidentId": ["rsa incident id"], "alertId": ["rsa alert id"]}
-
-                for key in alert:
-                    if key == "related_links":
-                        continue
-
-                    elif key == "events":
-                        continue
-
-                    elif key in cef_keys:
-                        cef[cef_keys[key]] = alert[key]
-                        continue
-
-                    cef[key] = alert[key]
-
-                for event in alert["events"]:
-                    artifact = {}
-                    artifacts.append(artifact)
-                    artifact.update(artifact_common)
-
-                    cef = {}
-                    artifact["cef"] = cef
-                    artifact["label"] = "event"
-                    cef["alertId"] = alert["id"]
-                    artifact["cef_types"] = {"sessionId": ["netwitness session ids"], "alertId": ["rsa alert id"]}
-
-                    for key in event:
-                        if not event[key]:
-                            continue
-
-                        if key == "destination" or key == "source":
-                            device = event[key]["device"]
-                            for d_key in device:
-                                if d_key in cef_keys and device[d_key]:
-                                    cef[f"{key}{cef_keys[d_key]}"] = device[d_key]
-
-                            if event[key]["user"]:
-                                cef[f"{key}UserName"] = event[key]["user"]["username"]
-
-                        elif key == "related_links":
-                            for link in event[key]:
-                                if link["type"] == "investigate_original_event":
-                                    event_id = link["url"].split("/")[-1]
-                                    cef["sessionId"] = event_id
-                                    event_id_list.append(event_id)
-                                    artifact["source_data_identifier"] = event_id
-                                    artifact["name"] = f"event - {event_id}"
-
-                        elif key == "data":
-                            if event[key][0]["filename"]:
-                                cef["fileName"] = event[key][0]["filename"]
-                            if event[key][0]["size"]:
-                                cef["fileSize"] = event[key][0]["size"]
-                            if event[key][0]["hash"]:
-                                cef["fileHash"] = event[key][0]["hash"]
-
-                        elif key == "domain":
-                            cef["destinationDnsDomain"] = event[key]
-
-                        elif key == "timestamp":
-                            cef["createTime"] = event[key]
-
-                        elif key == "device":
-                            cef["deviceName"] = event[key]
-                            artifact["cef_types"]["deviceName"] = ["rsa sa device"]
-
-                        elif key == "file" or key == "size":
-                            pass
-
-                        elif key == "detector":
-                            pass
-
-                        else:
-                            cef[key] = event[key]
-
-        except:
-            pass
+            artifacts.append(alert_artifact)
+            for event in alert.get("events") or []:
+                try:
+                    artifacts.append(_parse_event(alert, event, event_ids))
+                except Exception as error:
+                    identifier = event.get("id") if isinstance(event, dict) else event
+                    _log_parse_error(base_connector, "event", identifier, error)
 
     return results

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* chore: establish the Codex vulnerability-remediation baseline.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * Encode alert identifiers before placing them in list-events request paths. [PSAAS-30642]
+* Enable TLS certificate verification by default while retaining an explicit opt-out. [PSAAS-30786]

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -2,3 +2,4 @@
 
 * Encode alert identifiers before placing them in list-events request paths. [PSAAS-30642]
 * Enable TLS certificate verification by default while retaining an explicit opt-out. [PSAAS-30786]
+* Bound alert and event pagination and stop safely on empty or overshooting pages. [PSAAS-32089]

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-* chore: establish the Codex vulnerability-remediation baseline.
+* Encode alert identifiers before placing them in list-events request paths. [PSAAS-30642]

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -3,3 +3,4 @@
 * Encode alert identifiers before placing them in list-events request paths. [PSAAS-30642]
 * Enable TLS certificate verification by default while retaining an explicit opt-out. [PSAAS-30786]
 * Bound alert and event pagination and stop safely on empty or overshooting pages. [PSAAS-32089]
+* Isolate malformed incident records and defensively parse adversary-influenced event fields. [PSAAS-32368]

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -4,3 +4,4 @@
 * Enable TLS certificate verification by default while retaining an explicit opt-out. [PSAAS-30786]
 * Bound alert and event pagination and stop safely on empty or overshooting pages. [PSAAS-32089]
 * Isolate malformed incident records and defensively parse adversary-influenced event fields. [PSAAS-32368]
+* Advance ingestion checkpoints only after every fetched incident and artifact is durably saved. [PSAAS-32186]

--- a/rsasa.json
+++ b/rsasa.json
@@ -5,7 +5,7 @@
     "publisher": "Splunk",
     "package_name": "phantom_rsasa",
     "type": "siem",
-    "license": "Copyright (c) 2017-2025 Splunk Inc.",
+    "license": "Copyright (c) 2017-2026 Splunk Inc.",
     "main_module": "rsasa_connector.py",
     "app_version": "2.0.6",
     "utctime_updated": "2025-09-05T16:47:45.545711Z",

--- a/rsasa.json
+++ b/rsasa.json
@@ -31,7 +31,7 @@
             "data_type": "boolean",
             "description": "Verify server certificate",
             "order": 1,
-            "default": false
+            "default": true
         },
         "username": {
             "required": true,

--- a/rsasa_connector.py
+++ b/rsasa_connector.py
@@ -87,7 +87,7 @@ class RSASAConnector(phantom.BaseConnector):
         data = {"j_username": config[consts.RSASA_JSON_USERNAME], "j_password": config[consts.RSASA_JSON_PASSWORD]}
 
         try:
-            r = self._session.post(url, data=data, verify=config[consts.RSASA_JSON_VERIFY_SERVER_CERT])
+            r = self._session.post(url, data=data, verify=config.get(consts.RSASA_JSON_VERIFY_SERVER_CERT, True))
         except Exception as e:
             if self.get_action_identifier() == self.ACTION_ID_TEST_ASSET_CONNECTIVITY:
                 self.save_progress(consts.RSASA_ERR_TEST_CONNECTIVITY)
@@ -168,7 +168,7 @@ class RSASAConnector(phantom.BaseConnector):
         url = f"{config[consts.RSASA_JSON_URL]}/j_spring_security_logout"
 
         try:
-            self._session.get(url, verify=config[consts.RSASA_JSON_VERIFY_SERVER_CERT])
+            self._session.get(url, verify=config.get(consts.RSASA_JSON_VERIFY_SERVER_CERT, True))
         except Exception as e:
             self.debug_print(f"Logout failed: {e!s}")
 
@@ -213,7 +213,7 @@ class RSASAConnector(phantom.BaseConnector):
 
         # Make the call
         try:
-            r = self._session.get(url, params=params, verify=config[consts.RSASA_JSON_VERIFY_SERVER_CERT], headers=headers)
+            r = self._session.get(url, params=params, verify=config.get(consts.RSASA_JSON_VERIFY_SERVER_CERT, True), headers=headers)
         except Exception as e:
             return RetVal(result.set_status(phantom.APP_ERROR, consts.RSASA_ERR_SERVER_CONNECTION, e), resp_json)
 
@@ -454,7 +454,7 @@ class RSASAConnector(phantom.BaseConnector):
             return RetVal(phantom.APP_ERROR, "Could not extract file hash. Could not find investigate URL.")
 
         try:
-            r = self._session.get(investigate_url, verify=self.get_config()[consts.RSASA_JSON_VERIFY_SERVER_CERT])
+            r = self._session.get(investigate_url, verify=self.get_config().get(consts.RSASA_JSON_VERIFY_SERVER_CERT, True))
         except Exception as e:
             return RetVal(phantom.APP_ERROR, f"Unable to connect to server. Error: {e!s}")
 
@@ -479,7 +479,11 @@ class RSASAConnector(phantom.BaseConnector):
             url = f"{self._base_url}/investigation/{device_id}/reconstruction/{event_id}/fileview"
 
             try:
-                r = self._session.post(url, data={"ctoken": self._csrf}, verify=self.get_config()[consts.RSASA_JSON_VERIFY_SERVER_CERT])
+                r = self._session.post(
+                    url,
+                    data={"ctoken": self._csrf},
+                    verify=self.get_config().get(consts.RSASA_JSON_VERIFY_SERVER_CERT, True),
+                )
             except Exception as e:
                 return RetVal(phantom.APP_ERROR, f"Unable to connect to server. Error: {e!s}")
 

--- a/rsasa_connector.py
+++ b/rsasa_connector.py
@@ -21,6 +21,7 @@ import json
 import re
 import time
 from datetime import datetime, timedelta
+from urllib.parse import quote
 
 import phantom.app as phantom
 import requests
@@ -409,7 +410,8 @@ class RSASAConnector(phantom.BaseConnector):
     def _get_events(self, action_result, alert, limit):
         """get all events for an alert"""
 
-        endpoint = f"/ajax/alerts/events/{self._inc_mgnt_id}/{alert}"
+        encoded_alert = quote(str(alert), safe="")
+        endpoint = f"/ajax/alerts/events/{self._inc_mgnt_id}/{encoded_alert}"
         query_params = {
             "start": 0,
             "limit": limit if limit is not None else consts.RSASA_DEFAULT_PAGE_SIZE,

--- a/rsasa_connector.py
+++ b/rsasa_connector.py
@@ -556,12 +556,15 @@ class RSASAConnector(phantom.BaseConnector):
         if param:
             container_count = param.get(phantom.APP_JSON_CONTAINER_COUNT, consts.RSASA_DEFAULT_CONTAINER_COUNT)
 
+        total_results = len(results)
         results = results[:container_count]
+        failed = total_results - len(results)
 
         for i, result in enumerate(results):
             container = result.get("container")
 
             if not container:
+                failed += 1
                 continue
 
             self.send_progress(f"Saving Container # {i + 1}")
@@ -570,6 +573,7 @@ class RSASAConnector(phantom.BaseConnector):
                 (ret_val, message, container_id) = self.save_container(container)
             except Exception as e:
                 self.debug_print("Handled Exception while saving container", e)
+                failed += 1
                 continue
 
             self.debug_print(f"save_container returns, value: {ret_val}, reason: {message}, id: {container_id}")
@@ -578,11 +582,13 @@ class RSASAConnector(phantom.BaseConnector):
                 self.save_progress(message)
                 message = "Failed to add Container for id: {}, error msg: {}".format(container.get("source_data_identifier", "N/A"), message)
                 self.debug_print(message)
+                failed += 1
                 continue
 
             if not container_id:
                 message = "save_container did not return a container_id"
                 self.debug_print(message)
+                failed += 1
                 continue
 
             artifacts = result.get("artifacts")
@@ -591,8 +597,10 @@ class RSASAConnector(phantom.BaseConnector):
 
             len_artifacts = len(artifacts)
 
+            incident_failed = False
             for j, artifact in enumerate(artifacts):
                 if not artifact:
+                    incident_failed = True
                     continue
 
                 # add the container id to the artifact
@@ -604,10 +612,20 @@ class RSASAConnector(phantom.BaseConnector):
                     # mark it such that active playbooks get executed
                     artifact["run_automation"] = True
 
-                ret_val, status_string, artifact_id = self.save_artifact(artifact)
+                try:
+                    ret_val, status_string, artifact_id = self.save_artifact(artifact)
+                except Exception as e:
+                    self.debug_print("Handled Exception while saving artifact", e)
+                    incident_failed = True
+                    continue
                 self.debug_print(f"save_artifact returns, value: {ret_val}, reason: {status_string}, id: {artifact_id}")
+                if phantom.is_fail(ret_val) or not artifact_id:
+                    incident_failed = True
 
-        return phantom.APP_SUCCESS
+            if incident_failed:
+                failed += 1
+
+        return failed
 
     def _get_time_range(self):
         # function to separate on poll and poll now
@@ -649,6 +667,8 @@ class RSASAConnector(phantom.BaseConnector):
         else:
             max_containers = config["max_incidents"]
 
+        was_first_run = self._state.get("first_run", True)
+        previous_checkpoint = self._state.get(consts.RSASA_JSON_LAST_DATE_TIME)
         start_time, end_time = self._get_time_range()
 
         self.save_progress(
@@ -688,18 +708,30 @@ class RSASAConnector(phantom.BaseConnector):
 
         self.save_progress(f"Got {len(incidents)} incidents")
 
+        results = pi.parse_incidents(incidents, self)
+        failed_saves = self._parse_results(action_result, param, results)
+
         if not self.is_poll_now():
-            if len(incidents) == int(max_containers):
+            if failed_saves:
+                self._state["first_run"] = was_first_run
+                if previous_checkpoint is None:
+                    self._state.pop(consts.RSASA_JSON_LAST_DATE_TIME, None)
+                else:
+                    self._state[consts.RSASA_JSON_LAST_DATE_TIME] = previous_checkpoint
+                self.debug_print(f"{failed_saves} incident(s) were not durably saved; checkpoint was not advanced")
+            elif len(incidents) == int(max_containers):
                 self._state[consts.RSASA_JSON_LAST_DATE_TIME] = incidents[-1]["created"] + 1
             else:
                 self._state[consts.RSASA_JSON_LAST_DATE_TIME] = end_time + 1
 
-        results = pi.parse_incidents(incidents, self)
-
-        self._parse_results(action_result, param, results)
-
         # blank line to update the last status message
         self.send_progress("")
+
+        if failed_saves:
+            return action_result.set_status(
+                phantom.APP_ERROR,
+                f"Failed to durably save {failed_saves} of {len(results)} incidents; checkpoint not advanced",
+            )
 
         return action_result.set_status(phantom.APP_SUCCESS)
 

--- a/rsasa_connector.py
+++ b/rsasa_connector.py
@@ -386,7 +386,7 @@ class RSASAConnector(phantom.BaseConnector):
         alerts = []
         page = 1
         total = 0
-        while True:
+        while page <= consts.RSASA_MAX_PAGES:
             query_params["page"] = page
 
             ret_val, data = self._make_rest_call(endpoint, action_result, params=query_params)
@@ -397,13 +397,21 @@ class RSASAConnector(phantom.BaseConnector):
             if not total:
                 total = data["total"]
 
-            alerts += data.get("data")
+            page_data = data.get("data") or []
+            if not page_data:
+                break
+
+            alerts += page_data
 
             len_alerts = len(alerts)
-            if len_alerts == total or (limit and len_alerts == limit):
+            if len_alerts >= total or (limit and len_alerts >= limit):
                 break
 
             page += 1
+
+        bounds = [bound for bound in (limit, total) if bound]
+        if bounds:
+            alerts = alerts[: min(bounds)]
 
         return RetVal(phantom.APP_SUCCESS, alerts)
 
@@ -421,7 +429,7 @@ class RSASAConnector(phantom.BaseConnector):
         events = []
         page = 1
         total = 0
-        while True:
+        while page <= consts.RSASA_MAX_PAGES:
             query_params["page"] = page
 
             ret_val, data = self._make_rest_call(endpoint, action_result, params=query_params)
@@ -432,13 +440,21 @@ class RSASAConnector(phantom.BaseConnector):
             if not total:
                 total = data["total"]
 
-            events += data.get("data")
+            page_data = data.get("data") or []
+            if not page_data:
+                break
+
+            events += page_data
 
             len_events = len(events)
-            if len(events) == total or (limit and len_events == limit):
+            if len_events >= total or (limit and len_events >= limit):
                 break
 
             page += 1
+
+        bounds = [bound for bound in (limit, total) if bound]
+        if bounds:
+            events = events[: min(bounds)]
 
         return RetVal(phantom.APP_SUCCESS, events)
 

--- a/rsasa_connector.py
+++ b/rsasa_connector.py
@@ -1,6 +1,6 @@
 # File: rsasa_connector.py
 #
-# Copyright (c) 2017-2025 Splunk Inc.
+# Copyright (c) 2017-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rsasa_consts.py
+++ b/rsasa_consts.py
@@ -1,6 +1,6 @@
 # File: rsasa_consts.py
 #
-# Copyright (c) 2017-2025 Splunk Inc.
+# Copyright (c) 2017-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rsasa_consts.py
+++ b/rsasa_consts.py
@@ -30,6 +30,7 @@ RSASA_ERR_JSON_PARSE = "Unable to parse reply, raw string reply: '{raw_text}'"
 RSASA_REST_CALL_FAIL = "Call to server failed with error code: {0}, message: {1}"
 
 RSASA_DEFAULT_PAGE_SIZE = 100
+RSASA_MAX_PAGES = 1000
 RSASA_DEFAULT_ALERT_LIMIT = 100
 RSASA_DEFAULT_EVENT_LIMIT = 100
 RSASA_DEFAULT_CONTAINER_COUNT = 100


### PR DESCRIPTION
## Summary

- encode alert identifiers before constructing request paths
- enable connector-owned TLS certificate verification by default
- bound alert and event pagination
- isolate malformed incident records while preserving later evidence
- advance polling checkpoints only after durable container and artifact saves

## Tracking

- Epic: ESPM-5228
- PAPP: PAPP-37992
- PSAAS-30642
- PSAAS-30786
- PSAAS-32089
- PSAAS-32186
- PSAAS-32368

PSAAS-31628 is intentionally excluded under the operator read_only policy and is not part of this PR.

## Validation

- full pre-commit suite passed under Python 3.13
- connector static tests and Semgrep passed
- Python compilation and git diff checks passed
- all commits are signed

Authored by Codex.

## Tracking

- PAPP: PAPP-37992
- PSAAS: PSAAS-30642, PSAAS-30786, PSAAS-32089, PSAAS-32186, PSAAS-32368
- Written by Codex.