### PR TITLE
fix: harden RSA Security Analytics ingestion

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.15.22
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: v1.42.1
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -43,12 +43,12 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.136.0
+    rev: v1.165.0
     hooks:
       - id: semgrep
         additional_dependencies: ["setuptools==81.0.0"]
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.8
     hooks:
       - id: build-docs
         language: python

--- a/parse_incidents.py
+++ b/parse_incidents.py
@@ -12,6 +12,15 @@
 # the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
 # either express or implied. See the License for the specific language governing permissions
 # and limitations under the License.
+import unicodedata
+
+
+def _strip_format_controls(value):
+    if not isinstance(value, str):
+        return value
+    return "".join(character for character in value if unicodedata.category(character) != "Cf")
+
+
 container_common = {
     "description": "Container added by Phantom",
 }
@@ -104,7 +113,7 @@ def _parse_event(alert, event, event_ids):
         elif key == "data":
             data = value[0] if isinstance(value, list) and value else {}
             if data.get("filename"):
-                cef["fileName"] = data["filename"]
+                cef["fileName"] = _strip_format_controls(data["filename"])
             if data.get("size"):
                 cef["fileSize"] = data["size"]
             if data.get("hash"):
@@ -131,8 +140,8 @@ def parse_incidents(incidents, base_connector):
             container = {}
             artifacts = []
             container["data"] = incident
-            container["name"] = "{} - {}".format(incident["id"], incident["name"])
-            container["description"] = incident["summary"]
+            container["name"] = "{} - {}".format(incident["id"], _strip_format_controls(incident["name"]))
+            container["description"] = _strip_format_controls(incident["summary"])
             container["source_data_identifier"] = incident["id"]
         except Exception as error:
             identifier = incident.get("id") if isinstance(incident, dict) else incident

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * Handle RSA Security Analytics event responses without file metadata. [PSAAS-32821]
+* Remove Unicode format controls from ingested RSA Security Analytics text. [PSAAS-33223]

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-* chore: refresh development tooling.
+* Handle RSA Security Analytics event responses without file metadata. [PSAAS-32821]

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* chore: refresh development tooling.

--- a/rsasa_connector.py
+++ b/rsasa_connector.py
@@ -336,15 +336,17 @@ class RSASAConnector(phantom.BaseConnector):
             return ret_val
 
         for event in events:
-            if event["data"][0]["filename"] and not event["data"][0]["hash"]:
+            data = event.get("data") or []
+            file_data = data[0] if data and isinstance(data[0], dict) else {}
+            if file_data.get("filename") and not file_data.get("hash"):
                 self._extract_device_and_hash(event)
 
         action_result.add_data(events)
         action_result.set_summary({"num_events": len(events)})
 
         for event in events:
-            for link in event["related_links"]:
-                if link["type"] == "investigate_original_event":
+            for link in event.get("related_links") or []:
+                if link.get("type") == "investigate_original_event" and link.get("url"):
                     event["id"] = link["url"].split("/")[-1]
 
         return action_result.set_status(phantom.APP_SUCCESS)
@@ -461,8 +463,8 @@ class RSASAConnector(phantom.BaseConnector):
     def _extract_device_and_hash(self, event):
         investigate_url = ""
         event_id = ""
-        for link in event["related_links"]:
-            if link["type"] == "investigate_original_event":
+        for link in event.get("related_links") or []:
+            if link.get("type") == "investigate_original_event" and link.get("url"):
                 investigate_url = "{}{}".format(self._base_url, link["url"])
                 event_id = link["url"].split("/")[-1]
 
@@ -483,7 +485,9 @@ class RSASAConnector(phantom.BaseConnector):
         device_name = r.text[device_name_index:].split("'")[0]
         event["device"] = device_name
 
-        if event["data"][0]["filename"] and not event["data"][0]["hash"]:
+        data = event.get("data") or []
+        file_data = data[0] if data and isinstance(data[0], dict) else {}
+        if file_data.get("filename") and not file_data.get("hash"):
             search_token = "deviceId: "
 
             if search_token not in r.text:
@@ -503,7 +507,12 @@ class RSASAConnector(phantom.BaseConnector):
             except Exception as e:
                 return RetVal(phantom.APP_ERROR, f"Unable to connect to server. Error: {e!s}")
 
-            for entry in r.json()["data"].get("fileList")[0]:
+            response_data = r.json().get("data") or {}
+            file_list = response_data.get("fileList") or []
+            if not file_list:
+                return RetVal(phantom.APP_ERROR, "Could not find file metadata in response.")
+
+            for entry in file_list[0] or []:
                 if "MD5" not in entry:
                     continue
 


### PR DESCRIPTION
### Bug Fixes

- Handle normal RSA Security Analytics event responses that omit file metadata without aborting the list-events action.
- Remove Unicode format-control characters from externally sourced incident names, summaries, and event filenames before SOAR stores them.

### Manual Documentation

- [x] I have verified that manual documentation is not required for these internal ingestion-handling changes.

### Other information

Tracking: ESPM-5228, PAPP-38291, PSAAS-32821, and PSAAS-33223.

PSAAS-32934 is already fixed by merged PR #24 and was closed as an Invalid duplicate; PSAAS-33528 is platform-owned and intentionally excluded.

The Unicode handling is a structural removal of category Cf controls, not a semantic allowlist; PSAAS-33223 cites Unicode TR36 and TR9 as the source basis.

Validation: Python 3.13 compilation, focused Unicode ingestion exercise, `git diff --check`, and full pre-commit completed with public PyPI after the internal mirror returned a zero-byte Ruff wheel.

All commits are signed. Written by Codex.

---
Please refer to the [Contribution Guide](https://github.com/splunk-soar-connectors/.github/blob/main/.github/CONTRIBUTING.md) for questions.

Merge strategy: merge commit only; do not squash